### PR TITLE
Fix watch:src task

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -62,9 +62,9 @@ module.exports = function(grunt) {
         files: '<%%= jshint.gruntfile.src %>',
         tasks: ['jshint:gruntfile']
       },
-      src: {
-        files: '<%%= jshint.src.src %>',
-        tasks: ['jshint:src', 'qunit']
+      app: {
+        files: '<%%= jshint.app.src %>',
+        tasks: ['jshint:app', 'qunit']
       },
       test: {
         files: '<%%= jshint.test.src %>',


### PR DESCRIPTION
watch:src pointed to non-existing jshint:src, fixed and renamed to watch:app for consistency.
