### PR TITLE
Use `bower_components` directory

### DIFF
--- a/app/templates/README.md
+++ b/app/templates/README.md
@@ -49,6 +49,7 @@ modules. Past that, well, the world is your oyster.
 
 ### Tests
 
+Note: you need [phantomJS](http://phantomjs.org) to run the tests.
 The test directory uses `qunit`, which is run using phantomJS
 in the console, but can also be ran by launching the server
 `grunt preview` and going to `localhost:8000/test/index.html`.

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -16,7 +16,7 @@
   "licenses": [
     {
       "type": "MIT",
-      "url": "https://github.com/danheberden/gith/blob/master/LICENSE-MIT"
+      "url": "http://mit-license.org"
     }
   ],
   "devDependencies": {

--- a/app/templates/app/config.js
+++ b/app/templates/app/config.js
@@ -2,8 +2,8 @@ require.config({
   // make components more sensible
   // expose jquery 
   paths: {
-    "components": "../components",
-    "jquery": "../components/jquery/jquery"
+    "components": "../bower_components",
+    "jquery": "../bower_components/jquery/jquery"
   }
 });
 

--- a/app/templates/app/main.js
+++ b/app/templates/app/main.js
@@ -1,5 +1,5 @@
 // to depend on a bower installed component:
-// define(['component/componentName/file'])
+// define(['bower_components/componentName/file'])
 
 define(["jquery"], function($) {
   $('body').append('jQuery ' + $.fn.jquery + ' loaded!');

--- a/app/templates/gitignore
+++ b/app/templates/gitignore
@@ -1,2 +1,3 @@
 node_modules/
+bower_components/
 temp/

--- a/app/templates/gitignore
+++ b/app/templates/gitignore
@@ -1,3 +1,4 @@
 node_modules/
 bower_components/
 temp/
+dist/

--- a/app/templates/index.htm
+++ b/app/templates/index.htm
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title><%= appdescription %></title>
-  <script data-main="app/config" src="components/requirejs/require.js"></script>
+  <script data-main="app/config" src="bower_components/requirejs/require.js"></script>
 </head>
 <body>
   <h1><%= appname %> running!</h1>

--- a/app/templates/test/index.html
+++ b/app/templates/test/index.html
@@ -4,13 +4,13 @@
   <meta charset="utf-8">
   <title>Test Suite</title>
   <!-- Load local QUnit. -->
-  <link rel="stylesheet" href="../components/qunit/qunit.css" media="screen">
-  <script src="../components/qunit/qunit.js"></script>
+  <link rel="stylesheet" href="../bower_components/qunit/qunit.css" media="screen">
+  <script src="../bower_components/qunit/qunit.js"></script>
   <script>
     QUnit.config.autostart = false;
   </script>
 
-  <script data-main="../app/config" src="../components/requirejs/require.js"></script> 
+  <script data-main="../app/config" src="../bower_components/requirejs/require.js"></script> 
   <script>
     window.requireTestMode = true;
     require.config({


### PR DESCRIPTION
The bower project is now using a `bower_components` directory, so this generator should adopt that convention. This pull request also updates the license URL to a better default (fixes issue #2), and documents the phantomJS dependency.
