### PR TITLE
Fix color issues and failing tests

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -2,6 +2,7 @@
 var util = require('util');
 var path = require('path');
 var yeoman = require('yeoman-generator');
+var chalk = require('chalk');
 
 
 var AppGenerator = module.exports = function AppGenerator(args, options, config) {
@@ -26,13 +27,12 @@ AppGenerator.prototype.askFor = function askFor() {
   var welcome =
   '\n     _-----_' +
   '\n    |       |' +
-  '\n    |' + '--(o)--'.red + '|   .--------------------------.' +
-  '\n   `---------´  |    ' + 'Welcome to Yeoman,'.yellow.bold + '    |' +
-  '\n    ' + '( '.yellow + '_' + '´U`'.yellow + '_' + ' )'.yellow + '   |   ' + 'ladies and gentlemen!'.yellow.bold + '  |' +
-  '\n    /___A___\\   \'__________________________\'' +
-  '\n     |  ~  |'.yellow +
-  '\n   __' + '\'.___.\''.yellow + '__' +
-  '\n ´   ' + '`  |'.red + '° ' + '´ Y'.red + ' `\n';
+  '\n    |' + chalk.red('--(o)--') + '|   .--------------------------.' +
+  '\n   `---------´  |    ' + chalk.yellow.bold('Welcome to Yeoman') + ',    |' +
+  '\n    ' + chalk.yellow('(') + ' _' + chalk.yellow('´U`') + '_ ' + chalk.yellow(')') + '   |   ' + chalk.yellow.bold('ladies and gentlemen!') + '  |' +  '\n    /___A___\\   \'__________________________\'' +
+  '\n     ' + chalk.yellow('|  ~  |') +
+  '\n   __' + chalk.yellow('\'.___.\'') + '__' +
+  '\n ´   ' + chalk.red('`  |') + '° ' + chalk.red('´ Y') + ' `\n';
 
   console.log(welcome);
   console.log('This comes with requirejs, jquery, and grunt all ready to go');

--- a/app/index.js
+++ b/app/index.js
@@ -54,11 +54,7 @@ AppGenerator.prototype.askFor = function askFor() {
     default: 'An awesome requirejs app'
   }];
 
-  this.prompt(prompts, function (err, props) {
-    if (err) {
-      return this.emit('error', err);
-    }
-
+  this.prompt(prompts, function (props) {
     this.appname = props.appname;
     this.appdescription = props.appdescription;
 

--- a/app/templates/test/index.html
+++ b/app/templates/test/index.html
@@ -4,13 +4,13 @@
   <meta charset="utf-8">
   <title>Test Suite</title>
   <!-- Load local QUnit. -->
-  <link rel="stylesheet" href="../components/qunit/qunit.css" media="screen">
-  <script src="../components/qunit/qunit.js"></script>
+  <link rel="stylesheet" href="../bower_components/qunit/qunit/qunit.css" media="screen">
+  <script src="../bower_components/qunit/qunit/qunit.js"></script>
   <script>
     QUnit.config.autostart = false;
   </script>
 
-  <script data-main="../app/config" src="../components/requirejs/require.js"></script> 
+  <script data-main="../app/config" src="../bower_components/requirejs/require.js"></script> 
   <script>
     window.requireTestMode = true;
     require.config({

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
     "test": "mocha"
   },
   "dependencies": {
-    "yeoman-generator": "~0.10.5"
+    "yeoman-generator": "~0.13.4"
   },
   "devDependencies": {
-    "mocha": "~1.9.0"
+    "mocha": "~1.12.1"
   },
   "engines": {
     "node": ">=0.8.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test": "mocha"
   },
   "dependencies": {
-    "yeoman-generator": "~0.13.4"
+    "yeoman-generator": "~0.13.4",
+    "chalk": "~0.2.0"
   },
   "devDependencies": {
     "mocha": "~1.12.1"

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -12,7 +12,7 @@ describe('yeoman-generator-requirejs generator', function () {
         return done(err);
       }
 
-      this.app = helpers.createGenerator('yeoman-generator-requirejs:app', [
+      this.app = helpers.createGenerator('requirejs:app', [
         '../../app'
       ]);
       done();


### PR DESCRIPTION
Hey there!

I installed this generator this morning, but noticed it was failing on the `yellow.bold` call at https://github.com/danheberden/yeoman-generator-requirejs/blob/master/app/index.js#L30. 

Even after bumping the dependencies, as suggested [here](https://github.com/yeoman/generator-webapp/issues/137), the error was still occurring, so I used chalk, just as was done in [this commit](https://github.com/yeoman/generator/commit/3c60110). Fixed!

After that, I ran the specs and saw failures. The 3rd and 4th commits in this PR address this, but I'm a little iffy on them. In both of those commits, I couldn't (after a cursory search) track down what repo or change was actually responsible for breaking them (I'm assuming the two specs were passing before?). The fourth commit especially seems heavy-handed, as it just removes error checking, but I did take a cue from the webapp generator where [they only expect an answer object](https://github.com/yeoman/generator-webapp/blob/master/app/index.js#L64) in their prompt.

Happy to help/refactor/whatever, just let me know. Both tests passing locally and generators works just fine for me now on OS X 10.8.4. Thanks!
