### PR TITLE
Removing the ES5 option from .jshintrc

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,6 +1,5 @@
 {
     "node": true,
-    "es5": true,
     "esnext": true,
     "bitwise": true,
     "camelcase": true,


### PR DESCRIPTION
Linting now warns "ES5 option is now set per default"
