### PR TITLE
Es5 is set by default starting with Jshint 2.0.0

### DIFF
--- a/app/templates/jshintrc
+++ b/app/templates/jshintrc
@@ -10,6 +10,5 @@
   "unused": true,
   "boss": true,
   "eqnull": true,
-  "node": true,
-  "es5": true
+  "node": true
 }


### PR DESCRIPTION
http://jslinterrors.com/es5-option-is-now-set-per-default/
