### PR TITLE
Resolve issue avoiding preview-task to run

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -91,18 +91,16 @@ module.exports = function(grunt) {
         options: {
           keepalive: true,
           port: 8000,
-          middleware: function(connect, options) {
-            return [
+          middleware: function(connect, options, middlewares) {
               // rewrite requirejs to the compiled version
-              function(req, res, next) {
+              middlewares.push(function(req, res, next) {
                 if (req.url === '/bower_components/requirejs/require.js') {
                   req.url = '/dist/require.min.js';
                 }
                 next();
-              },
-              connect.static(options.base),
+              });
 
-            ];
+              return middlewares;
           }
         }
       }

--- a/app/templates/jshintrc
+++ b/app/templates/jshintrc
@@ -10,6 +10,5 @@
   "unused": true,
   "boss": true,
   "eqnull": true,
-  "node": true,
-  "es5": true
+  "node": true
 }


### PR DESCRIPTION
First problem:

```
$ grunt preview-live
Running "jshint:gruntfile" (jshint) task

   Gruntfile.js
>> ES5 option is now set per default

>> 1 error in 1 file
Warning: Task "jshint:gruntfile" failed. Use --force to continue.

Aborted due to warnings.
```

As mentioned in [this article](http://jslinterrors.com/es5-option-is-now-set-per-default)
and discoused in [this issue](https://github.com/jshint/jshint/issues/1137)
The solution is to remove the option `ES5` from `.jshintrc`.

Second problem:

```
$ grunt preview-live
Running "jshint:gruntfile" (jshint) task
>> 1 file lint free.

Running "jshint:app" (jshint) task
>> 2 files lint free.

Running "jshint:test" (jshint) task
>> 1 file lint free.

Running "qunit:files" (qunit) task
Testing test/index.html .OK
>> 1 assertions passed (95ms)

Running "clean:files" (clean) task

Running "requirejs:compile" (requirejs) task

Running "concat:dist" (concat) task
File dist/require.js created.

Running "uglify:dist" (uglify) task
File dist/require.min.js created: 330.82 kB → 101.33 kB

Running "connect:production" (connect) task
Warning: Arguments to path.resolve must be strings Use --force to continue.

Aborted due to warnings.
```

Rewrited the `middleware` option following
[the documentation](https://www.npmjs.org/package/grunt-contrib-connect)

And:

```
$ grunt preview-live
Running "jshint:gruntfile" (jshint) task
>> 1 file lint free.

Running "jshint:app" (jshint) task
>> 2 files lint free.

Running "jshint:test" (jshint) task
>> 1 file lint free.

Running "qunit:files" (qunit) task
Testing test/index.html .OK
>> 1 assertions passed (64ms)

Running "clean:files" (clean) task

Running "requirejs:compile" (requirejs) task

Running "concat:dist" (concat) task
File dist/require.js created.

Running "uglify:dist" (uglify) task
File dist/require.min.js created: 330.82 kB → 101.33 kB

Running "connect:production" (connect) task
Waiting forever...
Started connect web server on http://0.0.0.0:8000
```
